### PR TITLE
CircleCI integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Distant Shore
+
+[![CircleCI build status](https://circleci.com/gh/unreasonent/distant-shore.svg)](https://circleci.com/gh/unreasonent/distant-shore)

--- a/bin/collate-test-results
+++ b/bin/collate-test-results
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+DIR="$1"
+
+mkdir -p "${DIR}/junit"
+find . \
+    -path '*/build/test-results/TEST-*.xml' \
+    -exec cp {} "${DIR}/junit/" ';'

--- a/bin/use-pull-request-merge
+++ b/bin/use-pull-request-merge
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    exit 0
+fi
+
+git fetch origin "refs/pull/${CIRCLE_PR_NUMBER}/merge"
+git checkout FETCH_HEAD

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+---
+machine:
+    java:
+        version: oraclejdk8
+
+checkout:
+    post:
+        - bin/use-pull-request-merge
+
+dependencies:
+    post:
+        - ./gradlew stage
+
+test:
+    post:
+        - bin/collate-test-results "${CIRCLE_TEST_REPORTS}"


### PR DESCRIPTION
Validating the merge result increases the chances that a test run reflects whether the integrated code works, which should help us catch integration bugs.