### PR TITLE
Return a static HTML view on all routes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,13 +10,18 @@ dependencies {
     ext {
         // Ensure all dropwizard components share a version.
         dropwizardVersion = '0.9.2'
+
+        hamcrestVersion = '1.3'
     }
 
     compile group: 'io.dropwizard', name: 'dropwizard-core', version: dropwizardVersion
+    compile group: 'io.dropwizard', name: 'dropwizard-views-freemarker', version: dropwizardVersion
 
     compile group: 'com.loginbox.heroku', name: 'dropwizard-heroku-config', version: '1.0.0'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: hamcrestVersion
+    testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: hamcrestVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
 }
 

--- a/app/src/main/java/com/unreasonent/ds/DistantShore.java
+++ b/app/src/main/java/com/unreasonent/ds/DistantShore.java
@@ -1,8 +1,10 @@
 package com.unreasonent.ds;
 
-import com.loginbox.heroku.config.HerokuConfiguration;
+import com.unreasonent.ds.frontend.FrontendBundle;
 import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.views.ViewBundle;
 
 /**
  * The Distant Shore server. For simplicity, this uses bundles for all of the actual app logic.
@@ -10,6 +12,17 @@ import io.dropwizard.setup.Environment;
 public class DistantShore extends Application<DistantShoreConfiguration> {
     public static void main(String[] args) throws Exception {
         new DistantShore().run(args);
+    }
+
+    private final ViewBundle<DistantShoreConfiguration> viewBundle
+            = new ViewBundle<>();
+    private final FrontendBundle frontendBundle
+            = new FrontendBundle();
+
+    @Override
+    public void initialize(Bootstrap<DistantShoreConfiguration> bootstrap) {
+        bootstrap.addBundle(viewBundle);
+        bootstrap.addBundle(frontendBundle);
     }
 
     @Override

--- a/app/src/main/java/com/unreasonent/ds/frontend/FrontendBundle.java
+++ b/app/src/main/java/com/unreasonent/ds/frontend/FrontendBundle.java
@@ -1,0 +1,18 @@
+package com.unreasonent.ds.frontend;
+
+import com.unreasonent.ds.frontend.resources.Frontend;
+import io.dropwizard.Bundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+public class FrontendBundle implements Bundle {
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {
+        /* No bundles, just resources. */
+    }
+
+    @Override
+    public void run(Environment environment) {
+        environment.jersey().register(new Frontend());
+    }
+}

--- a/app/src/main/java/com/unreasonent/ds/frontend/api/FrontendView.java
+++ b/app/src/main/java/com/unreasonent/ds/frontend/api/FrontendView.java
@@ -1,0 +1,13 @@
+package com.unreasonent.ds.frontend.api;
+
+import io.dropwizard.views.View;
+
+/**
+ * Abuse Dropwizard Views to generate and return the frontend HTML. This is simpler than trying to serve a static asset,
+ * weirdly.
+ */
+public class FrontendView extends View {
+    public FrontendView() {
+        super("/index.html.ftl");
+    }
+}

--- a/app/src/main/java/com/unreasonent/ds/frontend/resources/Frontend.java
+++ b/app/src/main/java/com/unreasonent/ds/frontend/resources/Frontend.java
@@ -1,0 +1,20 @@
+package com.unreasonent.ds.frontend.resources;
+
+import com.unreasonent.ds.frontend.api.FrontendView;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * Provides a fallback route that serves the front-end HTML, in cases where no other route matches the request. This
+ * relies on being the only route that provides {@code text/html} content, as well as on ordering.
+ */
+@Path("/{path:.*}")
+public class Frontend {
+    @GET
+    @Produces("text/html")
+    public FrontendView get() {
+        return new FrontendView();
+    }
+}

--- a/app/src/main/resources/index.html.ftl
+++ b/app/src/main/resources/index.html.ftl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Distant Shore</title>
+</head>
+
+<body>
+<div id="app">hi, you</div>
+</body>
+</html>

--- a/app/src/test/java/com/unreasonent/ds/BundleTestCase.java
+++ b/app/src/test/java/com/unreasonent/ds/BundleTestCase.java
@@ -1,0 +1,21 @@
+package com.unreasonent.ds;
+
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BundleTestCase {
+    @SuppressWarnings("unchecked")
+    protected final Bootstrap<DistantShoreConfiguration> bootstrap = mock(Bootstrap.class);
+    protected final Environment environment = mock(Environment.class);
+    protected final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
+
+    @Before
+    public void wireMocks() {
+        when(environment.jersey()).thenReturn(jersey);
+    }
+}

--- a/app/src/test/java/com/unreasonent/ds/DistantShoreTest.java
+++ b/app/src/test/java/com/unreasonent/ds/DistantShoreTest.java
@@ -1,13 +1,13 @@
 package com.unreasonent.ds;
 
-import io.dropwizard.Bundle;
-import io.dropwizard.ConfiguredBundle;
+import com.unreasonent.ds.frontend.FrontendBundle;
+import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.views.ViewBundle;
 import org.junit.Test;
 
-import static org.mockito.Mockito.any;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class DistantShoreTest {
@@ -20,12 +20,12 @@ public class DistantShoreTest {
     public void registersBundles() {
         app.initialize(bootstrap);
 
-        verify(bootstrap, never()).addBundle(any(Bundle.class));
-        verify(bootstrap, never()).addBundle(anyConfiguredBundle());
+        verify(bootstrap).addBundle(isViewBundle());
+        verify(bootstrap).addBundle(isA(FrontendBundle.class));
     }
 
     @SuppressWarnings("unchecked")
-    private <T> ConfiguredBundle<T> anyConfiguredBundle() {
-        return any(ConfiguredBundle.class);
+    private <T extends Configuration> ViewBundle<T> isViewBundle() {
+        return isA(ViewBundle.class);
     }
 }

--- a/app/src/test/java/com/unreasonent/ds/frontend/FrontendBundleTest.java
+++ b/app/src/test/java/com/unreasonent/ds/frontend/FrontendBundleTest.java
@@ -1,0 +1,20 @@
+package com.unreasonent.ds.frontend;
+
+import com.unreasonent.ds.BundleTestCase;
+import com.unreasonent.ds.frontend.resources.Frontend;
+import io.dropwizard.views.ViewBundle;
+import org.junit.Test;
+
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
+
+public class FrontendBundleTest extends BundleTestCase {
+    @Test
+    public void registersResources() {
+        FrontendBundle bundle = new FrontendBundle();
+
+        bundle.run(environment);
+
+        verify(jersey).register(isA(Frontend.class));
+    }
+}

--- a/app/src/test/java/com/unreasonent/ds/frontend/resources/FrontendTest.java
+++ b/app/src/test/java/com/unreasonent/ds/frontend/resources/FrontendTest.java
@@ -1,0 +1,19 @@
+package com.unreasonent.ds.frontend.resources;
+
+import com.unreasonent.ds.frontend.api.FrontendView;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+public class FrontendTest {
+    @Test
+    public void getFrontendView() {
+        Frontend resource = new Frontend();
+
+        FrontendView view = resource.get();
+
+        assertThat(view, not(nullValue()));
+    }
+}


### PR DESCRIPTION
It doesn't exist _yet_, but this will support HTML5 client-side routing once we have a client app.

This is also the first inkling of the bundle system I have in mind. The gist is that every major functional block gets its own bundle, so that dependencies can be kept simple (or at least kept visible).